### PR TITLE
[464] Utiliser une image Docker en CI avec la future version de Node

### DIFF
--- a/node16-python3.7-cy/Dockerfile
+++ b/node16-python3.7-cy/Dockerfile
@@ -1,0 +1,65 @@
+FROM buildpack-deps:buster
+
+ENV NODE_VERSION=v16.13.1
+ENV PYTHON_VERSION=3.7.10
+
+# install Node
+RUN wget https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION.tar.gz \ 
+    && tar -xzvf node-$NODE_VERSION.tar.gz \ 
+    && rm node-$NODE_VERSION.tar.gz \ 
+    && cd node-$NODE_VERSION \ 
+    && ./configure \ 
+    && make -j4 \ 
+    && make install \ 
+    && cd .. \ 
+    && rm -r node-$NODE_VERSION
+
+# install Python
+RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz \ 
+    && tar xzf Python-$PYTHON_VERSION.tgz \ 
+    && rm Python-$PYTHON_VERSION.tgz \ 
+    && cd Python-$PYTHON_VERSION \ 
+    && ./configure \ 
+    && make install
+
+# Install dependencies and cypress prerequisites cf. https://docs.cypress.io/guides/guides/continuous-integration.html#Advanced-setup
+RUN apt-get update \
+    && apt-get install -y \ 
+        lsb-release \ 
+        unzip \ 
+        libgtk2.0-0 \ 
+        libgtk-3-0 \ 
+        libgbm-dev \ 
+        libnotify-dev \ 
+        libgconf-2-4 \ 
+        libnss3 \ 
+        libxss1 \ 
+        libasound2 \ 
+        libxtst6 \ 
+        xauth \ 
+        xvfb
+
+# Set display for Xvfb
+ENV DISPLAY :99
+
+# install firefox
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.deb https://s3.amazonaws.com/circle-downloads/firefox-mozilla-build_47.0.1-0ubuntu1_amd64.deb \ 
+    && echo 'ef016febe5ec4eaf7d455a34579834bcde7703cb0818c80044f4d148df8473bb  /tmp/firefox.deb' | sha256sum -c \ 
+    && dpkg -i /tmp/firefox.deb || apt-get -f install \ 
+    && apt-get install -y libgtk3.0-cil-dev libasound2 libasound2 libdbus-glib-1-2 libdbus-1-3 \ 
+    && rm -rf /tmp/firefox.deb
+
+# install chrome
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \ 
+    && (dpkg -i /tmp/google-chrome-stable_current_amd64.deb || apt-get -fy install) \ 
+    && rm -rf /tmp/google-chrome-stable_current_amd64.deb \ 
+    && sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g'        "/opt/google/chrome/google-chrome"
+
+# install chromedriver
+RUN apt-get -y install libgconf-2-4 \ 
+    && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/2.33/chromedriver_linux64.zip" \ 
+    && cd /tmp \ 
+    && unzip chromedriver_linux64.zip \ 
+    && rm -rf chromedriver_linux64.zip \ 
+    && mv chromedriver /usr/local/bin/chromedriver \ 
+    && chmod +x /usr/local/bin/chromedriver

--- a/node16-python3.7-cy/Dockerfile
+++ b/node16-python3.7-cy/Dockerfile
@@ -49,8 +49,7 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-
 # install chromedriver
 RUN apt-get -y install libgconf-2-4 \ 
     && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/2.33/chromedriver_linux64.zip" \ 
-    && cd /tmp \ 
-    && unzip chromedriver_linux64.zip \ 
-    && rm -rf chromedriver_linux64.zip \ 
-    && mv chromedriver /usr/local/bin/chromedriver \ 
+    && unzip /tmp/chromedriver_linux64.zip \ 
+    && rm -rf /tmp/chromedriver_linux64.zip \ 
+    && mv /tmp/chromedriver /usr/local/bin/chromedriver \ 
     && chmod +x /usr/local/bin/chromedriver

--- a/node16-python3.7-cy/Dockerfile
+++ b/node16-python3.7-cy/Dockerfile
@@ -1,30 +1,13 @@
-FROM buildpack-deps:buster
+FROM node:16-buster-slim
 
-ENV NODE_VERSION=v16.13.1
 ENV PYTHON_VERSION=3.7.10
 
-# install Node
-RUN wget https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION.tar.gz \ 
-    && tar -xzvf node-$NODE_VERSION.tar.gz \ 
-    && rm node-$NODE_VERSION.tar.gz \ 
-    && cd node-$NODE_VERSION \ 
-    && ./configure \ 
-    && make -j4 \ 
-    && make install \ 
-    && cd .. \ 
-    && rm -r node-$NODE_VERSION
-
-# install Python
-RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz \ 
-    && tar xzf Python-$PYTHON_VERSION.tgz \ 
-    && rm Python-$PYTHON_VERSION.tgz \ 
-    && cd Python-$PYTHON_VERSION \ 
-    && ./configure \ 
-    && make install
-
-# Install dependencies and cypress prerequisites cf. https://docs.cypress.io/guides/guides/continuous-integration.html#Advanced-setup
+# Install package and cypress prerequisites cf. https://docs.cypress.io/guides/guides/continuous-integration.html#Advanced-setup
 RUN apt-get update \
     && apt-get install -y \ 
+        build-essential \ 
+        wget \ 
+        curl \ 
         lsb-release \ 
         unzip \ 
         libgtk2.0-0 \ 
@@ -38,6 +21,14 @@ RUN apt-get update \
         libxtst6 \ 
         xauth \ 
         xvfb
+
+# install Python
+RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz \ 
+    && tar xzf Python-$PYTHON_VERSION.tgz \ 
+    && rm Python-$PYTHON_VERSION.tgz \ 
+    && cd Python-$PYTHON_VERSION \ 
+    && ./configure \ 
+    && make install
 
 # Set display for Xvfb
 ENV DISPLAY :99


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/bnc8lqIv/464-utiliser-une-image-docker-en-ci-avec-la-future-version-de-node)

## Notes

### Versions
- pour l’image Debian je serais d’avis de rester sur la version buster (10) au lieu de passer à bulleye (11+). Même si l’image est stable elle a été release pour la première fois le 14/08/2021, avec la dernière release (11.2) distribuée le 18 décembre 2021
- pour le variant de l’image, étant donné que c'est pour un usage limité je suis d'avis de partir sur l'image Buster-slim avec Node 16 proposée par le repo [docker-node](https://github.com/nodejs/docker-node/blob/6f740b0ca772e978b44c11d194f369e554c54a14/16/buster-slim/Dockerfile) officiel de NodeJS. L'image est de taille plus réduite que Buster et permet de toujours avoir la dernière version de Node (cf point suivant). Ça permet également de ne pas utiliser nvm / nodesource / le [package n](https://www.npmjs.com/package/n) ou une installation manuelle comme précédemment
- pour Node, je propose de partir sur la version LTS (16.13.1 avec NPM 8.1.2). plutôt que la current (17.3.0 avec NPM 8.3.0)
- pour Python je propose de partir sur la version 3.7.10 qui reste compatible avec nos usages tout en ayant des patchs de sécurité supplémentaires par rapport à 3.7.3

### Points d'attention
- l'image utilise toujours `wget` / `curl` là où la bonne pratique d'un Dockerfile voudrait qu'on utilise que l'un des deux
- je n'ai pas touché aux versions des navigateurs pour la CI ;  de mon point de vue ça n'est pas un risque de sécu et ça permet d'être sûr de ne pas intégrer de features supportées que par des navigateurs très récents (< 2 ans)
- j'ai réuni les `apt install` que j'exécute d'ailleurs dans la même boucle `RUN` que l'apt update pour éviter des problèmes de cache (cf [Best Practices for writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get)